### PR TITLE
Adjust API error UI on AskNoora

### DIFF
--- a/src/components/ask-noora/AskNoora.tsx
+++ b/src/components/ask-noora/AskNoora.tsx
@@ -10,6 +10,7 @@ export default function AskNoora() {
       explanation:
         "You should show them that you are interested in their experiences by asking them about their book.",
       reply: "That's great! What was your favorite part of the book?",
+      success: true,
     },
   ]);
   const [rq, setRq] = useState<any[]>([]);

--- a/src/components/interfaces/ask-noora/AskNooraComponent.tsx
+++ b/src/components/interfaces/ask-noora/AskNooraComponent.tsx
@@ -55,6 +55,7 @@ export default function AskNooraComponent({
                   id={result.id}
                   statement={result.statement}
                   explanation={result.explanation}
+                  success={result.success}
                   reply={result.reply}
                   results={results}
                 />

--- a/src/components/interfaces/ask-noora/Result.tsx
+++ b/src/components/interfaces/ask-noora/Result.tsx
@@ -4,6 +4,7 @@ import { clsx } from "clsx";
 export default function Result({
   statement,
   explanation,
+  success,
   reply,
   id,
   results,
@@ -40,16 +41,20 @@ export default function Result({
           </span>
         )}
       </div>
-      {reply ? (
-        <div className="text-center mt-3 text-lg text-gray-600 max-w-4xl mx-auto">
-          {explanation} <br />
-          For example: <span className="text-noora-primary font-bold inline-block mt-1">“{reply}”</span>
-        </div>
-      ) : (
-        <div className="text-center text-slate-500">
+      {reply ? 
+        (<div className="text-center mt-3 text-lg text-gray-600 max-w-4xl mx-auto">
+            {success ?
+            <>
+              {explanation} <br />
+              For example: <span className="text-noora-primary font-bold inline-block mt-1">“{reply}”</span>
+            </>
+             : 
+            <span className="text-noora font-bold inline-block mt-1">{reply}</span>}
+        </div>) 
+      : (<div className="text-center text-slate-500">
           Give Noora a few seconds to think...
-        </div>
-      )}
+        </div>)
+      }
     </div>
   );
 }
@@ -58,6 +63,7 @@ type ResultProps = {
   statement: string;
   explanation: string;
   reply: string;
+  success: boolean;
   id: number;
   results: any;
 };

--- a/src/scripts/gpt-3/generate-advice.ts
+++ b/src/scripts/gpt-3/generate-advice.ts
@@ -11,7 +11,8 @@ export default async function generateResult(statement: string, uuid: string) {
 
   let numApiCalls = 0;
   let explanation = "";
-  let reply = "Noora couldn't think of a reply.";
+  let reply = "Noora couldn't think of a reply. Please try again.";
+  let success = false;
   while (numApiCalls < 3) {
     let result = await Completion({
       model: "text-davinci-002",
@@ -27,6 +28,7 @@ export default async function generateResult(statement: string, uuid: string) {
     if (tokens.length == 2) {
       explanation = tokens[0].trim();
       reply = tokens[1].trim().replace('"', "");
+      success = true;
       break;
     }
   }
@@ -35,6 +37,7 @@ export default async function generateResult(statement: string, uuid: string) {
     id: uuid,
     statement: statement,
     explanation: explanation,
+    success: success,
     reply: reply.replace('"', ""),
   };
 }

--- a/src/scripts/gpt-3/generate-advice.ts
+++ b/src/scripts/gpt-3/generate-advice.ts
@@ -11,7 +11,7 @@ export default async function generateResult(statement: string, uuid: string) {
 
   let numApiCalls = 0;
   let explanation = "";
-  let reply = "Noora couldn't think of a reply. Please try again.";
+  let reply = "Noora couldn't think of a reply. Please try again later.";
   let success = false;
   while (numApiCalls < 3) {
     let result = await Completion({


### PR DESCRIPTION
### What:
Edits the UI when AskNoora API call fails. The new version better communicate to the user that they have to try again later and that the default reply is not a real response.

#### Old
<img width="1299" alt="Screenshot 2023-11-12 at 5 41 43 PM" src="https://github.com/stanford-oval/noora/assets/56043296/b5c9abac-a140-4ecf-b259-743117971a4b">

#### New
<img width="1209" alt="Screenshot 2023-11-12 at 7 49 04 PM" src="https://github.com/stanford-oval/noora/assets/56043296/6ce36048-c042-4878-a520-b568b05cf524">

### How:
- Adds a `success` parameter on the API result call and use it to conditionally render a successful reply or one asking users to try again

-  Edits the default reply to be "Noora couldn't think of a reply. **Please try again later**."

### Testing
I do not yet have access to the Azure API, if it could be tested that where I have placed the `success = True` actually works with our API call.